### PR TITLE
Fetching Dota Blog Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,14 @@ Want to try out mangobyte on your server? [Click Here](https://discordapp.com/oa
 ## Commands
 
 <!-- COMMANDS_START -->
-Mangobyte currently has 86 commands, separated into 7 categories
+Mangobyte currently has 87 commands, separated into 7 categories
 
 #### General
 Commands that don't really fit into the other categories
 
 ```
-?ask             | Answers any question you might have 
-?blog            | Pulls up the most recent Dota blog post                       
-?botstats        | Displays some bot statistics                                
+?ask             | Answers any question you might have                        
+?botstats        | Displays some bot statistics                               
 ?cat             | Gets a picture of my cat                                   
 ?changelog       | Gets a rough changelog for mangobyte                       
 ?choose          | Randomly chooses one of the given options                  
@@ -77,6 +76,7 @@ For information about Dota 2, and playing hero responses
 ?ability         | Gets information about a specific hero ability             
 ?addemoticon     | Adds a dota emoticon as an animated emoji                  
 ?aghanim         | Gets the aghs upgrade for the given hero or ability        
+?blog            | Pulls the newest blog post for Dota 2                      
 ?chatwheel       | Plays the given chat wheel sound                           
 ?courage         | Generates a challenge build                                
 ?dota            | Plays a dota response                                      

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Mangobyte currently has 86 commands, separated into 7 categories
 Commands that don't really fit into the other categories
 
 ```
-?ask             | Answers any question you might have                        
-?botstats        | Displays some bot statistics  
-?blog            | Pulls up the most recent Dota blog post                              
+?ask             | Answers any question you might have 
+?blog            | Pulls up the most recent Dota blog post                       
+?botstats        | Displays some bot statistics                                
 ?cat             | Gets a picture of my cat                                   
 ?changelog       | Gets a rough changelog for mangobyte                       
 ?choose          | Randomly chooses one of the given options                  

--- a/cogs/dotabase.py
+++ b/cogs/dotabase.py
@@ -1,5 +1,5 @@
 import discord
-from discord.ext import commands
+from discord.ext import commands, tasks
 from sqlalchemy.sql.expression import func
 from sqlalchemy import and_, or_
 from __main__ import settings, httpgetter
@@ -1448,6 +1448,13 @@ class Dotabase(MangoCog):
 		title = "Dota 2 Blog"
 		embed = rsstools.create_embed(title, blog.entries[0])
 		await ctx.send(embed = embed)
+
+	@tasks.loop(minutes=3)
+	async def check_dota_blog(self):
+                feed = await httpgetter.get(r'https://blog.dota2.com/feed', return_type="text")
+                blog = feedparser.parse(feed)
+                updated = rsstools.is_new_blog(blog.entries[0])
+                print(updated)
 
 	
 

--- a/cogs/dotabase.py
+++ b/cogs/dotabase.py
@@ -31,10 +31,10 @@ ABILITY_KEY_MAP = {
 }
 # some specific heroes have weird places for their ultimate keys
 ABILITY_ULTI_KEY_MAP = {
-	"3": 4, "10": 6, "19": 4, "23": 4, 
-	"54": 4, "68": 4, "73": 4, "74": 6, 
-	"86": 6, "88": 5, "89": 4, 
-	"90": 4, "91": 4, "98": 5, "100": 5, 
+	"3": 4, "10": 6, "19": 4, "23": 4,
+	"54": 4, "68": 4, "73": 4, "74": 6,
+	"86": 6, "88": 5, "89": 4,
+	"90": 4, "91": 4, "98": 5, "100": 5,
 	"103": 4, "108": 4, "110": 5, "114": 6, "120": 4
 }
 for i in range(1, 20):
@@ -176,7 +176,7 @@ class Dotabase(MangoCog):
 							hero_stats[stat["stat"]] = vars(hero)[stat["stat"]]
 				all_hero_stats.append(hero_stats)
 			self.leveled_hero_stats.append(all_hero_stats)
-		
+
 	def get_wiki_url(self, obj):
 		if isinstance(obj, Hero):
 			wikiurl = obj.localized_name
@@ -240,7 +240,7 @@ class Dotabase(MangoCog):
 					return ability
 				cleaned_name = cleaned_name.replace(" ", "")
 				if cleaned_name == text.replace(" ", ""):
-					return ability			
+					return ability
 			for ability in ability_query:
 				name = clean_input(ability.localized_name)
 				if " " in name:
@@ -262,7 +262,7 @@ class Dotabase(MangoCog):
 						custom_position = ABILITY_ULTI_KEY_MAP.get(str(hero.id))
 						if custom_position is not None and custom_position < len(abilities):
 							ability_position = custom_position
-						else: 
+						else:
 							ability_position = len(abilities)
 					return abilities[ability_position - 1]
 		return None
@@ -418,7 +418,7 @@ class Dotabase(MangoCog):
 
 		First tries to match the keyphrase with the name of a response
 
-		If there is no response matching the input string, searches for any response that has the input string as part of its text 
+		If there is no response matching the input string, searches for any response that has the input string as part of its text
 
 		To specify a specific hero to search for responses for, use ';' before the hero's name like this:
 		`{cmdpfx}dota ;rubick`
@@ -667,7 +667,7 @@ class Dotabase(MangoCog):
 		if not hero.is_melee:
 			attack_stats += f"{self.get_emoji('hero_projectile_speed')} {hero.attack_projectile_speed:,}\n"
 		embed.add_field(name="Attack", value=attack_stats)
-		
+
 		base_armor = hero.base_armor + round(hero.attr_agility_base / 6.0, 1)
 		embed.add_field(name="Defence", value=(
 			f"{self.get_emoji('hero_armor')} {base_armor:0.1f}\n"
@@ -923,7 +923,7 @@ class Dotabase(MangoCog):
 				text += f" {footer}"
 			text += "\n"
 			description += text
-			
+
 
 		if item.description:
 			if description != "":
@@ -1337,7 +1337,7 @@ class Dotabase(MangoCog):
 		if tier is not None:
 			tier_color = drawdota.neutral_tier_colors[str(tier)]
 			embed.color = discord.Color(int(tier_color[1:], 16))
-		
+
 		if tier is None:
 			embed.set_footer(text="Also try: ?neutralitems tier 4")
 		await ctx.send(embed=embed, file=image)
@@ -1345,7 +1345,7 @@ class Dotabase(MangoCog):
 	@commands.command(aliases=["startingstats", "tradingstats", "lvlstats", "lvledstats"])
 	async def leveledstats(self, ctx, *, hero : str):
 		"""Gets the stats for a hero at the specified level
-		
+
 		If no level is specified, get the stats for the hero at level 1
 
 		**Examples:**
@@ -1393,14 +1393,14 @@ class Dotabase(MangoCog):
 		embed.set_thumbnail(url=f"{self.vpkurl}{hero.portrait}")
 		if hero.color:
 			embed.color = discord.Color(int(hero.color[1:], 16))
-		embed.set_footer(text="The stats shown above do not account for talents, passives, or items")		
-		
+		embed.set_footer(text="The stats shown above do not account for talents, passives, or items")
+
 		await ctx.send(embed=embed)
 
 	@commands.command(aliases=["statstable", "stattable", "heroestable", "leveledstatstable", "besthero", "bestheroes"])
 	async def herotable(self, ctx, *, table_args : HeroStatsTableArgs):
 		"""Displays a sorted table of heroes and their stats
-		
+
 		Displays a table with computed hero stats showing which heroes have the highest values for the specified stat. To see the list of possible stats, try the `{cmdpfx}leveledstats` command
 
 		**Examples:**
@@ -1439,11 +1439,11 @@ class Dotabase(MangoCog):
 
 		image = discord.File(await drawdota.draw_heroabilities(abilities), "abilities.png")
 		embed.set_image(url=f"attachment://{image.filename}")
-		
+
 		embed.color = discord.Color(int(hero.color[1:], 16))
-		
+
 		await ctx.send(embed=embed, file=image)
-		
+
 
 	@commands.command(aliases = ["rss"])
 	async def blog(self,ctx):
@@ -1456,47 +1456,46 @@ class Dotabase(MangoCog):
 
 	@tasks.loop(minutes=5)
 	async def check_dota_blog(self):
-                feed = await httpgetter.get(r'https://blog.dota2.com/feed', return_type="text")
-                blog = feedparser.parse(feed)
-                title = "Dota 2 Blog"
-                
-                updated = rsstools.is_new_blog(blog.entries[0])
-                if not updated: #if its not updated, stop here
-                        return
+		feed = await httpgetter.get(r'https://blog.dota2.com/feed', return_type="text")
+		blog = feedparser.parse(feed)
+		title = "Dota 2 Blog"
 
-                embed = rsstools.create_embed(title, blog.entries[0]) #generate embed
+		updated = rsstools.is_new_blog(blog.entries[0])
+		if not updated: #if its not updated, stop here
+			return
 
-                ##next section copies code in check_dota_patch in general cogs
-                messageables = []
-                #find channels to post in
-                guildinfos = botdata.guildinfo_list()
-                for guildinfo in guildinfos:
-                        if guildinfo.dotablogchannel is not None:
-                                channel = self.bot.get_channel(guildinfo.dotablogchannel)
-                                if channel is not None:
-                                        messageables.append(channel)
-                                else:
-                                        print(f"couldn't find channel {guildinfo.dotablogchannel} when announcing dota blog")
-                
-                 #find users
-                userinfos = botdata.userinfo_list()
-                for userinfo in userinfos:
-                        if userinfo.dmdotablog:
-                                user = self.bot.get_user(userinfo.discord)
-                                if user is not None:
-                                        messageables.append(user)
-                                else:
-                                        print(f"couldn't find user {userinfo.discord} when announcing dota blog")
+		embed = rsstools.create_embed(title, blog.entries[0]) #generate embed
 
-                #bundle tasks and execute
-                tasks = []
-                for messageable in messageables:
-                        tasks.append(messageable.send(embed=embed))
+		##next section copies code in check_dota_patch in general cogs
+		messageables = []
+		#find channels to post in
+		guildinfos = botdata.guildinfo_list()
+		for guildinfo in guildinfos:
+			if guildinfo.dotablogchannel is not None:
+				channel = self.bot.get_channel(guildinfo.dotablogchannel)
+				if channel is not None:
+					messageables.append(channel)
+				else:
+					print(f"couldn't find channel {guildinfo.dotablogchannel} when announcing dota blog")
 
-                bundler = AsyncBundler(tasks)
-                await bundler.wait()
-                
-                
+		#find users
+		userinfos = botdata.userinfo_list()
+		for userinfo in userinfos:
+			if userinfo.dmdotablog:
+				user = self.bot.get_user(userinfo.discord)
+				if user is not None:
+					messageables.append(user)
+				else:
+					print(f"couldn't find user {userinfo.discord} when announcing dota blog")
+
+		#bundle tasks and execute
+		tasks = []
+		for messageable in messageables:
+			tasks.append(messageable.send(embed=embed))
+
+		bundler = AsyncBundler(tasks)
+		await bundler.wait()
+
 
 def setup(bot):
 	bot.add_cog(Dotabase(bot))

--- a/cogs/utils/botdata.py
+++ b/cogs/utils/botdata.py
@@ -121,6 +121,13 @@ class UserInfo(BotDataItem):
 			"type": types.Boolean,
 			"description": "If enabled, mango will private message you when a new dota patch gets released",
 			"example": "enable"
+		},
+                {
+                        "key": "dmdotablog",
+                        "default": None,
+                        "type": types.Boolean,
+                        "description": "Enabling this will let mangobyte dm you about Dota blog updates",
+                        "example": "enable"
 		}
 	]
 

--- a/cogs/utils/botdata.py
+++ b/cogs/utils/botdata.py
@@ -218,6 +218,13 @@ class GuildInfo(BotDataItem):
 			"type": types.TextChannel,
 			"description": "The channel in which mangobyte will post to notify about new dota patches when it detects them",
 			"example": "#dota"
+		},
+                		{
+			"key": "dotablogchannel",
+			"default": None,
+			"type": types.TextChannel,
+			"description": "The channel to which mangobyte will post blog notifications",
+			"example": "#dota"
 		}
 	]
 
@@ -251,7 +258,8 @@ class BotData:
 		self.defaults = OrderedDict([ 
 			("userinfo" , []), 
 			("guildinfo" , []), 
-			("dotapatch", None) 
+			("dotapatch", None),
+                        ("dotablog",None)
 		])
 		if not os.path.exists(self.path):
 			self.json_data = self.defaults

--- a/cogs/utils/botdata.py
+++ b/cogs/utils/botdata.py
@@ -122,12 +122,12 @@ class UserInfo(BotDataItem):
 			"description": "If enabled, mango will private message you when a new dota patch gets released",
 			"example": "enable"
 		},
-                {
-                        "key": "dmdotablog",
-                        "default": None,
-                        "type": types.Boolean,
-                        "description": "Enabling this will let mangobyte dm you about Dota blog updates",
-                        "example": "enable"
+		{
+			"key": "dmdotablog",
+			"default": None,
+			"type": types.Boolean,
+			"description": "Enabling this will let mangobyte dm you about Dota blog updates",
+			"example": "enable"
 		}
 	]
 
@@ -135,10 +135,10 @@ class UserInfo(BotDataItem):
 		var = next((v for v in self.variables if v["key"] == key), None)
 		if var:
 			self[key] = var["default"]
-	
+
 class GuildInfo(BotDataItem):
 	def __init__(self, botdata, guildid):
-		defaults = OrderedDict([ 
+		defaults = OrderedDict([
 			("voicechannel", None),
 			("invalidcommands", False),
 			("banned_users", []),
@@ -226,7 +226,7 @@ class GuildInfo(BotDataItem):
 			"description": "The channel in which mangobyte will post to notify about new dota patches when it detects them",
 			"example": "#dota"
 		},
-                		{
+		{
 			"key": "dotablogchannel",
 			"default": None,
 			"type": types.TextChannel,
@@ -262,11 +262,11 @@ class GuildInfo(BotDataItem):
 class BotData:
 	def __init__(self):
 		self.path = "botdata.json"
-		self.defaults = OrderedDict([ 
-			("userinfo" , []), 
-			("guildinfo" , []), 
+		self.defaults = OrderedDict([
+			("userinfo" , []),
+			("guildinfo" , []),
 			("dotapatch", None),
-                        ("dotablog",None)
+			("dotablog",None)
 		])
 		if not os.path.exists(self.path):
 			self.json_data = self.defaults
@@ -344,4 +344,4 @@ class BotData:
 		else:
 			return "?"
 
-		
+

--- a/cogs/utils/rsstools.py
+++ b/cogs/utils/rsstools.py
@@ -6,7 +6,27 @@ import regex as re
 from __main__ import botdata
 from bs4 import BeautifulSoup
 
-    
+def is_new_blog(entry):
+    """Takes the newest dota blog entry, and checks data against record
+    returns a boolean
+    updates blog entry if it is new"""
+    new = parser.parse(entry.published) #date on 'new' entry
+    old = botdata.__getitem__("dotablog")
+    if new:
+        if old:
+            if parser.parse(old)< new:#compare and replace if new is greater
+                botdata.__setitem__("dotablog",entry.published)
+                return True
+            else:
+                return False
+        else:
+            botdata.__setitem__("dotablog",entry.published)#initialize if there is no prior date 
+            return False #but we don't want to post, so say it isn't new
+    else:
+        print("invalid record")
+        return False
+
+
 def create_embed(blog_title, entry):
     """ Takes a blog title and feedparser entry, and returns a rich embed object linking to the post"""
     response = discord.Embed(type='rich')

--- a/cogs/utils/rsstools.py
+++ b/cogs/utils/rsstools.py
@@ -23,7 +23,6 @@ def is_new_blog(entry):
             botdata.__setitem__("dotablog",entry.published)#initialize if there is no prior date 
             return False #but we don't want to post, so say it isn't new
     else:
-        print("invalid record")
         return False
 
 

--- a/cogs/utils/rsstools.py
+++ b/cogs/utils/rsstools.py
@@ -7,56 +7,56 @@ from __main__ import botdata
 from bs4 import BeautifulSoup
 
 def is_new_blog(entry):
-    """Takes the newest dota blog entry, and checks data against record
-    returns a boolean
-    updates blog entry if it is new"""
-    new = parser.parse(entry.published) #date on 'new' entry
-    old = botdata.__getitem__("dotablog")
-    if new:
-        if old:
-            if parser.parse(old)< new:#compare and replace if new is greater
-                botdata.__setitem__("dotablog",entry.published)
-                return True
-            else:
-                return False
-        else:
-            botdata.__setitem__("dotablog",entry.published)#initialize if there is no prior date 
-            return False #but we don't want to post, so say it isn't new
-    else:
-        return False
+	"""Takes the newest dota blog entry, and checks data against record
+	returns a boolean
+	updates blog entry if it is new"""
+	new = parser.parse(entry.published) #date on 'new' entry
+	old = botdata["dotablog"]
+	if new:
+		if old:
+			if parser.parse(old)< new:#compare and replace if new is greater
+				botdata["dotablog"]=entry.published
+				return True
+			else:
+				return False
+		else:
+			botdata["dotablog"]=entry.published#initialize if there is no prior date
+			return False #but we don't want to post, so say it isn't new
+	else:
+		return False
 
 
 def create_embed(blog_title, entry):
-    """ Takes a blog title and feedparser entry, and returns a rich embed object linking to the post"""
-    response = discord.Embed(type='rich')
+	""" Takes a blog title and feedparser entry, and returns a rich embed object linking to the post"""
+	response = discord.Embed(type='rich')
 
-    ### pull the hook from the entry html for introduction
-    soup = BeautifulSoup(entry.content[0]['value'], "html.parser")
-    first_paragraph = "" 
-    for p in soup.find_all('p'): #find first paragraph of text
-        if p.text != '':
-            first_paragraph = p.text
-            break
-    sentence = re.split('(?<=[.!?]) +',first_paragraph) #split the paragraph into sentences
-    hook = ""
-    if len(sentence)< 2: #limit hook to first two senteces of that paragraph
-        hook = first_paragraph
-    else:
-        hook = sentence[0]+' '+sentence[1]
-            
-    ###pull other data
-    link = entry.link #pull link for newest blog
-    published = parser.parse(entry.published) #date
-    image=soup.find("img" )
-    header = f'The {blog_title} has updated!'
+	### pull the hook from the entry html for introduction
+	soup = BeautifulSoup(entry.content[0]['value'], "html.parser")
+	first_paragraph = ""
+	for p in soup.find_all('p'): #find first paragraph of text
+		if p.text != '':
+			first_paragraph = p.text
+			break
+	sentence = re.split('(?<=[.!?]) +',first_paragraph) #split the paragraph into sentences
+	hook = ""
+	if len(sentence)< 2: #limit hook to first two senteces of that paragraph
+		hook = first_paragraph
+	else:
+		hook = sentence[0]+' '+sentence[1]
 
-    ###assign things to the embed object
-    response.title = entry.title
-    if image: #there may not be one
-        response.set_image(url = image["src"])
-        response.image.proxy_url=link
-    response.timestamp = published
-    response.add_field(name = header, value = hook , inline = False)
-    response.url = link
+	###pull other data
+	link = entry.link #pull link for newest blog
+	published = parser.parse(entry.published) #date
+	image=soup.find("img" )
+	header = f'The {blog_title} has updated!'
 
-    return response
+	###assign things to the embed object
+	response.title = entry.title
+	if image: #there may not be one
+		response.set_image(url = image["src"])
+		response.image.proxy_url=link
+	response.timestamp = published
+	response.add_field(name = header, value = hook , inline = False)
+	response.url = link
+
+	return response

--- a/mangobyte.py
+++ b/mangobyte.py
@@ -93,7 +93,7 @@ async def on_ready():
 		print('Connecting to voice channels if specified in botdata.json ...')
 
 	game = discord.Activity(
-		name="DOTA 3 [?help]", 
+		name="DOTA 3 [?help]",
 		type=discord.ActivityType.playing,
 		start=datetime.datetime.utcnow())
 	await bot.change_presence(status=discord.Status.online, activity=game)
@@ -108,7 +108,7 @@ async def on_ready():
 	periodic_tasks = [
 		general_cog.update_topgg,
 		general_cog.check_dota_patch,
-                dota_cog.check_dota_blog
+		dota_cog.check_dota_blog
 	]
 	# start topgg update service thing
 	for task in periodic_tasks:
@@ -127,7 +127,7 @@ async def on_ready():
 	if is_first_time:
 		print("\nupdating guilds")
 		await loggingdb.update_guilds(bot.guilds)
-	
+
 	finished_text = "initialization finished"
 	if not is_first_time:
 		finished_text = "re-" + finished_text
@@ -222,7 +222,7 @@ async def on_command_error(ctx, error):
 				new_message.content = cmdpfx + cmd.lower() + ctx.message.content[len(cmd) + 1:]
 				await bot.process_commands(new_message)
 			elif await invalid_command_reporting(ctx):
-				await ctx.send(f"🤔 Ya I dunno what a '{cmd}' is, but it ain't a command. Try `{cmdpfx}help` fer a list of things that ARE commands.") 
+				await ctx.send(f"🤔 Ya I dunno what a '{cmd}' is, but it ain't a command. Try `{cmdpfx}help` fer a list of things that ARE commands.")
 		elif isinstance(error, commands.CheckFailure):
 			emoji_dict = read_json(settings.resource("json/emoji.json"))
 			if botdata.guildinfo(ctx).is_disabled(ctx.command):
@@ -251,7 +251,7 @@ async def on_command_error(ctx, error):
 			await loggingdb.command_finished(ctx, "user_errored", error.original.message)
 		elif isinstance(error, commands.ConversionError) and isinstance(error.original, UserError):
 			await error.original.send_self(ctx, botdata)
-			await loggingdb.command_finished(ctx, "user_errored", error.original.message)					
+			await loggingdb.command_finished(ctx, "user_errored", error.original.message)
 		else:
 			await ctx.send("Uh-oh, sumthin dun gone wrong 😱")
 			trace_string = await report_error(ctx.message, error, skip_lines=4)
@@ -297,7 +297,7 @@ async def report_error(message, error, skip_lines=2):
 		if skip_lines > 0 and len(trace) >= (2 + skip_lines):
 			del trace[1:(skip_lines + 1)]
 		trace = [x for x in trace if x] # removes empty lines
-	
+
 	trace_string = "\n".join(trace)
 
 	await loggingdb.insert_error(message, error, trace_string)
@@ -311,7 +311,7 @@ def update_commandinfo():
 		"cogs": [],
 		"commands": []
 	}
-	commands = sorted(bot.commands, key=lambda c: c.name) 
+	commands = sorted(bot.commands, key=lambda c: c.name)
 	for cmd in commands:
 		if cmd.cog and cmd.cog.name == "Owner":
 			continue

--- a/mangobyte.py
+++ b/mangobyte.py
@@ -97,13 +97,15 @@ async def on_ready():
 
 	general_cog = bot.get_cog("General")
 	audio_cog = bot.get_cog("Audio")
+	dota_cog = bot.get_cog("Dotabase")
 	artifact_cog = bot.get_cog("Artifact")
 	await artifact_cog.load_card_sets()
 	bot.help_command.cog = bot.get_cog("General")
 
 	periodic_tasks = [
 		general_cog.update_topgg,
-		general_cog.check_dota_patch
+		general_cog.check_dota_patch,
+                dota_cog.check_dota_blog
 	]
 	# start topgg update service thing
 	for task in periodic_tasks:

--- a/resource/json/commands.json
+++ b/resource/json/commands.json
@@ -76,7 +76,8 @@
 				"aghs",
 				"ags",
 				"aghanims",
-				"scepter"
+				"scepter",
+				"shard"
 			],
 			"cog": "Dotabase"
 		},
@@ -87,6 +88,16 @@
 			"help": "Answers any question you might have",
 			"aliases": [],
 			"cog": "General"
+		},
+		{
+			"name": "blog",
+			"signature": "?blog ",
+			"short_help": "Pulls the newest blog post for Dota 2",
+			"help": "Pulls the newest blog post for Dota 2",
+			"aliases": [
+				"rss"
+			],
+			"cog": "Dotabase"
 		},
 		{
 			"name": "botban",
@@ -184,7 +195,7 @@
 			"name": "config",
 			"signature": "?config <name> [value]",
 			"short_help": "Configures the bot's settings for this server",
-			"help": "Configures the bot's settings for this server\n\nBelow are the different settings that you can tweak to customize mangobyte for this server. You can get more information about a setting by typing `?config <settingname>`, and you can configure a setting by typing `?config <settingname> <value>`\n\n**Settings:**\n\u200b`prefix`\n\u200b`reactions`\n\u200b`ttschannel`\n\u200b`botadmin`\n\u200b`intros`\n\u200b`outros`\n\u200b`ttslang`\n\u200b`usenickname`\n\u200b`simpletts`\n\u200b`announcetts`\n\n**Examples**\n\u200b`?config prefix !`\n\u200b`?config reactions enable`\n\u200b`?config ttschannel #tts`\n\u200b`?config botadmin @BotAdmin`\n\u200b`?config intros disable`\n\u200b`?config outros disable`\n\u200b`?config ttslang Russian`\n\u200b`?config usenickname enable`\n\u200b`?config simpletts enable`\n\u200b`?config announcetts enable`",
+			"help": "Configures the bot's settings for this server\n\nBelow are the different settings that you can tweak to customize mangobyte for this server. You can get more information about a setting by typing `?config <settingname>`, and you can configure a setting by typing `?config <settingname> <value>`\n\n**Settings:**\n\u200b`prefix`\n\u200b`reactions`\n\u200b`ttschannel`\n\u200b`botadmin`\n\u200b`intros`\n\u200b`outros`\n\u200b`ttslang`\n\u200b`usenickname`\n\u200b`simpletts`\n\u200b`announcetts`\n\u200b`dotapatchchannel`\n\u200b`dotablogchannel`\n\n**Examples**\n\u200b`?config prefix !`\n\u200b`?config reactions enable`\n\u200b`?config ttschannel #tts`\n\u200b`?config botadmin @BotAdmin`\n\u200b`?config intros disable`\n\u200b`?config outros disable`\n\u200b`?config ttslang Russian`\n\u200b`?config usenickname enable`\n\u200b`?config simpletts enable`\n\u200b`?config announcetts enable`\n\u200b`?config dotapatchchannel #dota`\n\u200b`?config dotablogchannel #dota`",
 			"aliases": [],
 			"cog": "Admin"
 		},
@@ -251,7 +262,7 @@
 			"name": "dota",
 			"signature": "?dota [keyphrase]",
 			"short_help": "Plays a dota response",
-			"help": "Plays a dota response\n\nFirst tries to match the keyphrase with the name of a response\n\nIf there is no response matching the input string, searches for any response that has the input string as part of its text \n\nTo specify a specific hero to search for responses for, use ';' before the hero's name like this:\n\u200b`?dota ;rubick`\n\nTo specify a specific criteria to search for responses for, use ';' before the criteria name like this:\n\u200b`?dota ;rubick ;defeat`\nThere are some aliases for heroes, so the following will work:\n\u200b`?dota sf`\n\u200b`?dota furion`\n\u200b`?dota shredder`\n\nIf failing all of the above, the command will also try to find unlabeled heroes and critera. try:\n\u200b`?dota juggernaut bottling`\nA few critera you can use are: kill, bottling, cooldown, acknowledge, immortality, nomana, and select\n\nTo search for a response without asking mangobyte, try using the [Response Searcher](http://dotabase.dillerm.io/responses/)\nProTip: If you click the discord button next to the response in the above web app, it will copy to your clipboard in the format needed to play using the bot.",
+			"help": "Plays a dota response\n\nFirst tries to match the keyphrase with the name of a response\n\nIf there is no response matching the input string, searches for any response that has the input string as part of its text\n\nTo specify a specific hero to search for responses for, use ';' before the hero's name like this:\n\u200b`?dota ;rubick`\n\nTo specify a specific criteria to search for responses for, use ';' before the criteria name like this:\n\u200b`?dota ;rubick ;defeat`\nThere are some aliases for heroes, so the following will work:\n\u200b`?dota sf`\n\u200b`?dota furion`\n\u200b`?dota shredder`\n\nIf failing all of the above, the command will also try to find unlabeled heroes and critera. try:\n\u200b`?dota juggernaut bottling`\nA few critera you can use are: kill, bottling, cooldown, acknowledge, immortality, nomana, and select\n\nTo search for a response without asking mangobyte, try using the [Response Searcher](http://dotabase.dillerm.io/responses/)\nProTip: If you click the discord button next to the response in the above web app, it will copy to your clipboard in the format needed to play using the bot.",
 			"aliases": [
 				"dotar"
 			],
@@ -432,7 +443,8 @@
 			"short_help": "Tells the story of the player's last match",
 			"help": "Tells the story of the player's last match\n\nInput must be either a discord user, a steam32 id, or a steam64 id",
 			"aliases": [
-				"lastgamestory"
+				"lastgamestory",
+				"lmstory"
 			],
 			"cog": "DotaStats"
 		},
@@ -813,7 +825,7 @@
 			"name": "userconfig",
 			"signature": "?userconfig <name> [value]",
 			"short_help": "Configures the bot's user-specific settings",
-			"help": "Configures the bot's user-specific settings\n\nBelow are the different user-specific settings that you can tweak to customize mangobyte. You can get more information about a setting by typing `?userconfig <settingname>`, and you can configure a setting by typing `?userconfig <settingname> <value>`\n\n**Settings:**\n\u200b`steam`\n\u200b`intro`\n\u200b`outro`\n\u200b`introtts`\n\u200b`outrotts`\n\n**Examples**\n\u200b`?userconfig steam 70388657`\n\u200b`?userconfig intro local:math`\n\u200b`?userconfig outro dota:troll_warlord_troll_lose_03`\n\u200b`?userconfig introtts it's the magnificent`\n\u200b`?userconfig outrotts dun gone left`",
+			"help": "Configures the bot's user-specific settings\n\nBelow are the different user-specific settings that you can tweak to customize mangobyte. You can get more information about a setting by typing `?userconfig <settingname>`, and you can configure a setting by typing `?userconfig <settingname> <value>`\n\n**Settings:**\n\u200b`steam`\n\u200b`intro`\n\u200b`outro`\n\u200b`introtts`\n\u200b`outrotts`\n\u200b`dmdotapatch`\n\u200b`dmdotablog`\n\n**Examples**\n\u200b`?userconfig steam 70388657`\n\u200b`?userconfig intro local:math`\n\u200b`?userconfig outro dota:troll_warlord_troll_lose_03`\n\u200b`?userconfig introtts it's the magnificent`\n\u200b`?userconfig outrotts dun gone left`\n\u200b`?userconfig dmdotapatch enable`\n\u200b`?userconfig dmdotablog enable`",
 			"aliases": [],
 			"cog": "General"
 		},


### PR DESCRIPTION
Added a task to check when the blog has updated, then adjusted it so it can message users and channels when it detects a new post. I tried to keep the tracking of registered channels and messaging process similar to the process for the dota patch stuff, and leaned on existing functions and code as much as possible.  Can adjust as needed.

I also fixed the order on the command list for the readme, because I messed up alphabetical order last time. 