### PR TITLE
Add benchmark column to match_table

### DIFF
--- a/cogs/utils/drawdota.py
+++ b/cogs/utils/drawdota.py
@@ -306,18 +306,31 @@ def get_lane(player):
 	else:
 		return lane_role_dict[player.get('lane_role')]
 
+def get_benchmark(player):
+    benchmarks = player.get('benchmarks')
+    benchmark_keys = ['gold_per_min', 'xp_per_min', 'kills_per_min',
+                      'last_hits_per_min', 'hero_damage_per_min', 'hero_healing_per_min',
+                      'tower_damage', 'stuns_per_min', 'lhten']
+
+    # sum the benchmarks and average them
+    total = 0
+    for key in benchmark_keys:
+        total += benchmarks.get(key).get('pct')
+
+    return round((total / len(keys)) * 100)
 
 async def add_player_row(table, player, is_parsed, is_ability_draft, has_talents):
-	row = [
-		ColorCell(width=5, color=("green" if player["isRadiant"] else "red")),
-		ImageCell(img=await get_hero_image(player["hero_id"]), height=48),
-		ImageCell(img=await get_level_image(player.get("level", 1))),
-		TextCell(player.get("personaname", "Anonymous")),
-		TextCell(player.get("kills")),
-		TextCell(player.get("deaths")),
-		TextCell(player.get("assists")),
-		TextCell(player.get("gold_per_min"), color="yellow")
-	]
+    row = [
+        ColorCell(width=5, color=("green" if player["isRadiant"] else "red")),
+        ImageCell(img=await get_hero_image(player["hero_id"]), height=48),
+        ImageCell(img=await get_level_image(player.get("level", 1))),
+        TextCell(player.get("personaname", "Anonymous")),
+        TextCell(player.get("kills")),
+        TextCell(player.get("deaths")),
+        TextCell(player.get("assists")),
+        TextCell(f"{get_benchmark(player)}%"),
+        TextCell(player.get("gold_per_min"), color="yellow")
+    ]
 	if is_parsed:
 		row.extend([
 			TextCell(player.get("actions_per_min")),
@@ -352,6 +365,7 @@ async def draw_match_table(match):
 		TextCell("K", horizontal_align="center"),
 		TextCell("D", horizontal_align="center"),
 		TextCell("A", horizontal_align="center"),
+		TextCell("BM"), # BM for 'benchmark'
 		TextCell("GPM", color="yellow")
 	]
 	if is_parsed:


### PR DESCRIPTION
Hey @mdiller! Just want to say that I love MangoByte, it's an awesome bot!

Some friends and myself enjoy seeing how we generally performed as an overall percentage benchmark, as we feel it sums it up nicely. Forgive me if this is something you've added before and removed due to favoring other values more.

If implemented it would look something like:
<img width="1077" alt="Screen Shot 2021-03-02 at 4 59 31 PM" src="https://user-images.githubusercontent.com/47774408/109652459-40999b80-7b79-11eb-80b4-a3804800cf74.png">


Perhaps adding it only when a certain argument is passed may be better?
Let me know what you think 😄 