### PR TITLE
forced SQLAlchemy version 1.2.11 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ beautifulsoup4>=4.6.3
 colorgram.py==1.1.0
 gTTS>=2.2.1
 gTTS-token>=1.1.4
-SQLAlchemy>=1.2.11
+SQLAlchemy==1.2.11
 Pillow>=6.2.0
 youtube-dl>=2018.8.28
 dotabase>=7.2.3


### PR DESCRIPTION
Fixes some imports breaking with the newer versions of SQLAlchemy. Running `pip install -r requirements.txt` with `SQLAlchemy>=1.2.11` installs SQLAlchemy 1.4.18, which breaks some stuff. Traceback below: 

`Traceback (most recent call last):
  File "/Users/cadenwestmoreland/MangoByte/venv/lib/python3.8/site-packages/discord/client.py", line 343, in _run_event
    await coro(*args, **kwargs)
  File "mangobyte.py", line 110, in on_ready
    await artifact_cog.load_card_sets()
  File "/Users/cadenwestmoreland/MangoByte/cogs/artifact.py", line 30, in load_card_sets
    await self.update_card_sets()
  File "/Users/cadenwestmoreland/MangoByte/cogs/artifact.py", line 53, in update_card_sets
    set_data = await httpgetter.get(f"https://playartifact.com/cardset/{str(n).zfill(2)}")
  File "/Users/cadenwestmoreland/MangoByte/cogs/utils/httpgetter.py", line 118, in get
    await loggingdb.insert_http_request(url, r.status, cache)
  File "/Users/cadenwestmoreland/MangoByte/cogs/utils/loggingdb.py", line 269, in insert_http_request
    async with self.lock, Database(self.database_url) as database:
  File "/Users/cadenwestmoreland/MangoByte/venv/lib/python3.8/site-packages/databases/core.py", line 41, in __init__
    backend_cls = import_from_string(backend_str)
  File "/Users/cadenwestmoreland/MangoByte/venv/lib/python3.8/site-packages/databases/importer.py", line 21, in import_from_string
    raise exc from None
  File "/Users/cadenwestmoreland/MangoByte/venv/lib/python3.8/site-packages/databases/importer.py", line 18, in import_from_string
    module = importlib.import_module(module_str)
  File "/Users/cadenwestmoreland/anaconda3/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/cadenwestmoreland/MangoByte/venv/lib/python3.8/site-packages/databases/backends/sqlite.py", line 8, in <module>
    from sqlalchemy.engine.result import ResultMetaData, RowProxy
ImportError: cannot import name 'RowProxy' from 'sqlalchemy.engine.result' (/Users/cadenwestmoreland/MangoByte/venv/lib/python3.8/site-packages/sqlalchemy/engine/result.py)`