### PR TITLE
Hacked circular imports, replaced imports from main with imports from mangobyte

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -2,7 +2,7 @@ import discord
 import asyncio
 import shutil
 from discord.ext import commands
-from __main__ import settings, botdata, httpgetter, loggingdb
+from mangobyte import settings, botdata, httpgetter, loggingdb
 from cogs.utils.helpers import *
 from cogs.utils.botdata import GuildInfo
 from cogs.utils.clip import GttsLang

--- a/cogs/artifact.py
+++ b/cogs/artifact.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands
-from __main__ import settings, botdata, httpgetter
+from mangobyte import settings, botdata, httpgetter
 from cogs.utils.deck_decoder import ParseDeck
 from cogs.utils.helpers import *
 from cogs.utils.clip import *

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -2,7 +2,7 @@ import discord
 from discord.ext import commands
 from cogs.utils.helpers import *
 from cogs.utils.clip import *
-from __main__ import settings, botdata, report_error, loggingdb
+from mangobyte import settings, botdata, report_error, loggingdb
 from cogs.utils import checks
 import cogs.utils.botdatatypes as botdatatypes
 import asyncio

--- a/cogs/dotabase.py
+++ b/cogs/dotabase.py
@@ -2,7 +2,7 @@ import discord
 from discord.ext import commands, tasks
 from sqlalchemy.sql.expression import func
 from sqlalchemy import and_, or_, desc
-from __main__ import settings, httpgetter
+from mangobyte import settings, httpgetter
 from cogs.utils.helpers import *
 from cogs.utils.clip import *
 from cogs.utils.commandargs import *

--- a/cogs/dotastats.py
+++ b/cogs/dotastats.py
@@ -1,7 +1,7 @@
 from cogs.utils.metastats import get_total_pro_games
 import discord
 from discord.ext import commands
-from __main__ import settings, botdata, thinker, httpgetter
+from mangobyte import settings, botdata, thinker, httpgetter
 from cogs.utils import checks
 from cogs.utils.helpers import *
 from cogs.utils.commandargs import *

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands, tasks
-from __main__ import settings, botdata, invite_link, httpgetter, loggingdb
+from mangobyte import settings, botdata, invite_link, httpgetter, loggingdb
 from cogs.utils.helpers import *
 from cogs.utils.botdata import UserInfo
 from cogs.utils import checks, botdatatypes, wikipedia

--- a/cogs/mangocog.py
+++ b/cogs/mangocog.py
@@ -1,4 +1,4 @@
-from __main__ import settings, botdata, loggingdb
+from mangobyte import settings, botdata, loggingdb
 from cogs.utils.helpers import *
 from cogs.utils.clip import *
 import discord

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -4,7 +4,7 @@ import asyncio
 import shutil
 from sqlalchemy import desc
 from discord.ext import commands
-from __main__ import settings, botdata, httpgetter, loggingdb
+from mangobyte import settings, botdata, httpgetter, loggingdb
 from cogs.utils.helpers import *
 from cogs.utils.botdata import GuildInfo
 from cogs.utils.clip import GttsLang

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands
-from __main__ import settings, botdata, httpgetter
+from mangobyte import settings, botdata, httpgetter
 from cogs.utils.helpers import *
 from cogs.utils.clip import *
 from cogs.utils import checks

--- a/cogs/utils/botdatatypes.py
+++ b/cogs/utils/botdatatypes.py
@@ -1,4 +1,3 @@
-from __main__ import settings
 import discord
 from discord.ext import commands
 from abc import abstractmethod
@@ -145,18 +144,23 @@ class UserBot(ConfigVarType):
 		except commands.BadArgument:
 			raise InvalidInputError("Try giving me a bot reference like `@Bot123`")
 
-gtts_langs = read_json(settings.resource("json/gtts_languages.json"))
 
 class GttsLang(ConfigVarType):
+
+	@classmethod
+	def calc_gtts_langs():
+		from mangobyte import settings
+		return read_json(settings.resource("json/gtts_languages.json"))
+
 	@classmethod
 	async def _localize(cls, value, ctx):
-		return gtts_langs[value]
+		return cls.calc_gtts_langs()[value]
 
 	@classmethod
 	async def _parse(cls, value, ctx):
 		value = value.lower()
-		for lang in gtts_langs:
-			if lang.lower() == value or gtts_langs[lang].lower() == value:
+		for lang in cls.calc_gtts_langs():
+			if lang.lower() == value or cls.calc_gtts_langs()[lang].lower() == value:
 				if "-" in lang:
 					raise InvalidInputError("Languages with '-' have unfortunately been deprecated")
 				return lang

--- a/cogs/utils/checks.py
+++ b/cogs/utils/checks.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands
-from __main__ import botdata
+from mangobyte import botdata
 
 #
 # This is a "heavily" modified version of checks.py, originally made by Rapptz

--- a/cogs/utils/clip.py
+++ b/cogs/utils/clip.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from __main__ import settings, botdata, httpgetter
+from mangobyte import settings, botdata, httpgetter
 from .helpers import *
 from gtts import gTTS
 import urllib.request

--- a/cogs/utils/commandargs.py
+++ b/cogs/utils/commandargs.py
@@ -1,4 +1,4 @@
-from __main__ import settings, botdata, httpgetter
+from mangobyte import settings, botdata, httpgetter
 import re
 import discord
 from discord.ext import commands

--- a/cogs/utils/drawdota.py
+++ b/cogs/utils/drawdota.py
@@ -1,4 +1,4 @@
-from __main__ import settings, botdata, httpgetter
+from mangobyte import settings, botdata, httpgetter
 import aiohttp
 import asyncio
 import async_timeout

--- a/cogs/utils/helpcommand.py
+++ b/cogs/utils/helpcommand.py
@@ -1,4 +1,4 @@
-from __main__ import botdata, settings
+from mangobyte import botdata, settings
 import discord, itertools, inspect, re
 from discord.ext.commands import *
 from .botdata import GuildInfo, UserInfo

--- a/cogs/utils/httpgetter.py
+++ b/cogs/utils/httpgetter.py
@@ -1,4 +1,3 @@
-from __main__ import settings, loggingdb
 from .helpers import *
 import re
 import aiohttp
@@ -8,6 +7,7 @@ default_cache = { "count": 0, "files": {} }
 
 class Cache:
 	def __init__(self, loop):
+		from mangobyte import settings
 		self.loop = loop
 		self.cache_dir = settings.resource("cache/")
 		self.index_file = self.cache_dir + "cache_index.json"
@@ -115,6 +115,7 @@ class HttpGetter:
 			return self.cache.get(url, return_type)
 
 		async with self.session.get(url, timeout=60) as r:
+			from mangobyte import loggingdb
 			await loggingdb.insert_http_request(url, r.status, cache)
 			if r.status == 200:
 				if cache:
@@ -135,6 +136,7 @@ class HttpGetter:
 
 	async def post(self, url, return_type="json", errors={}, body={}, headers={}):
 		async with self.session.post(url, json=body, headers=headers) as r:
+			from mangobyte import loggingdb
 			await loggingdb.insert_http_request(url, r.status, False)
 			if r.status == 200:
 				if return_type == "json":

--- a/cogs/utils/loggingdb.py
+++ b/cogs/utils/loggingdb.py
@@ -1,4 +1,3 @@
-from __main__ import settings
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, Float, Boolean, ForeignKey, Table, DateTime
 from sqlalchemy.orm import sessionmaker, relationship
@@ -154,6 +153,7 @@ def row2dict(row):
 # inserters
 
 def print_debug(text):
+	from mangobyte import settings
 	if True or settings.debug:
 		print(text)
 

--- a/cogs/utils/rsstools.py
+++ b/cogs/utils/rsstools.py
@@ -3,7 +3,7 @@
 import discord
 from dateutil import parser
 import re
-from __main__ import botdata
+from mangobyte import botdata
 from bs4 import BeautifulSoup
 
 def is_new_blog(entry):

--- a/cogs/utils/settings.py
+++ b/cogs/utils/settings.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 #
 # loosely based off of the red discord bot's settings
 # to import from mangobyte.py, use:
-# from __main__ import settings
+# from mangobyte import settings
 #
 
 class Settings:

--- a/cogs/utils/tabledraw.py
+++ b/cogs/utils/tabledraw.py
@@ -1,4 +1,4 @@
-from __main__ import settings, botdata
+from mangobyte import settings, botdata
 from PIL import Image, ImageDraw, ImageFont
 from .imagetools import *
 import math

--- a/cogs/utils/wikipedia.py
+++ b/cogs/utils/wikipedia.py
@@ -1,4 +1,4 @@
-from __main__ import settings, httpgetter
+from mangobyte import settings, httpgetter
 from bs4 import BeautifulSoup, Tag
 from .helpers import *
 import re


### PR DESCRIPTION
The many imports from main throughout the project made it difficult to set up pytests and made things a bit less developer-friendly overall. Changing `from __main__ import foo` globally in the project resulted in several circular import issues. Wherever there were circular import issues, the imports were moved inside of the functions they were relevant to. This is essentially a band-aid to help get pytests up and running in a sane way for future contributions. 